### PR TITLE
2024/12/07 - version: 0.0.04+20

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,34 @@ A estrutura apresentada permite uma manutenção eficiente do código, tornando 
 
 # ChangeLog
 
+## 2024/12/07 - version: 0.0.04+20
+
+This commit refines the advertisement management system by enhancing the repository interface, improving method signatures, and updating Firestore integration for better flexibility and performance.
+
+### Changes made:
+
+1. **lib/features/account/my_ads/my_ads_controller.dart**:
+   - Updated `_getAds` method to use named parameters `ownerId` and `status` when calling `adRepository.getMyAds`.
+   - Refactored `updateStatus` method to pass `adsId`, `status`, and `quantity` explicitly to `adRepository.updateStatus`.
+   - Modified `deleteAd` method to use the updated `adRepository.updateStatus` method for marking ads as deleted.
+
+2. **lib/repository/data/firebase/fb_ads_repository.dart**:
+   - Added a new constant `keyAdsOwnerId` for the `ownerId` field in Firestore.
+   - Implemented the `getMyAds` method to fetch ads based on `ownerId` and `status` using Firestore queries.
+   - Updated `updateStatus` method to accept named parameters `adsId`, `status`, and `quantity` for improved clarity and flexibility.
+   - Removed obsolete and unimplemented methods, including old `getMyAds` and placeholders for `moveAdsAddressTo`.
+
+3. **lib/repository/data/interfaces/i_ads_repository.dart**:
+   - Refactored method signatures in the `IAdsRepository` interface to use named parameters for clarity.
+   - Removed extensive and outdated documentation for methods no longer relevant.
+   - Updated `updateStatus` method to require `adsId`, `status`, and `quantity` as named parameters.
+   - Simplified and streamlined method declarations to align with the latest implementation in Firestore.
+
+### Conclusion:
+
+These updates improve the modularity and maintainability of the advertisement management codebase. The repository interface now supports more flexible operations, and Firestore queries are streamlined for better performance. Deprecated methods and redundant documentation were cleaned up, ensuring the code remains clear and concise.
+
+
 ## 2024/12/07 - version: 0.0.04+19
 
 This commit introduces a major overhaul to replace the Parse Server implementation with Firebase, refactors model structures, simplifies repository logic, and removes unused Parse-specific functions and constants. Key changes include adjustments to model properties, repository interfaces, and managers to support Firebase operations and removal of Parse Server dependencies.

--- a/lib/features/account/my_ads/my_ads_controller.dart
+++ b/lib/features/account/my_ads/my_ads_controller.dart
@@ -46,8 +46,8 @@ class MyAdsController {
 
   Future<void> _getAds() async {
     final result = await adRepository.getMyAds(
-      currentUser.id!,
-      _productStatus.name,
+      ownerId: currentUser.id!,
+      status: _productStatus,
     );
     if (result.isFailure) {
       // FIXME: Complete this error handling
@@ -106,7 +106,11 @@ class MyAdsController {
     int currentPage = _adsDataBasePage;
     try {
       store.setStateLoading();
-      final result = await adRepository.updateStatus(ad);
+      final result = await adRepository.updateStatus(
+        adsId: ad.id!,
+        status: ad.status,
+        quantity: ad.quantity,
+      );
       if (result.isFailure) {
         throw Exception(result.error);
       }
@@ -133,7 +137,11 @@ class MyAdsController {
     try {
       store.setStateLoading();
       ad.status = AdStatus.deleted;
-      await adRepository.updateStatus(ad);
+      await adRepository.updateStatus(
+        adsId: ad.id!,
+        status: ad.status,
+        quantity: ad.quantity,
+      );
       await _getAds();
       store.setStateSuccess();
     } catch (err) {

--- a/lib/repository/data/interfaces/i_ads_repository.dart
+++ b/lib/repository/data/interfaces/i_ads_repository.dart
@@ -23,186 +23,81 @@ class AdsRepositoryException implements Exception {
 /// interact with various data sources, such as a backend service, a local
 /// database, or an in-memory cache.
 ///
-/// Example:
-/// ```dart
-/// class PSAdRepository implements IAdRepository {
-///   // Implementation of methods to interact with Parse Server.
-/// }
-/// ```
-///
 /// The interface aims to keep the advertisement logic abstracted away from the
 /// business logic, allowing for flexibility and scalability in the application
 /// architecture.
 abstract class IAdsRepository {
-  /// Moves multiple advertisements to a new address by updating the associated
-  /// address ID.
+  /// Adds a new ad to Firestore.
   ///
-  /// This method takes a list of advertisement IDs (`adsIdList`) and assigns
-  /// them all to a new address (`moveToId`). It does this by creating a
-  /// `ParseObject` for each ad, updating its address to point to the new
-  /// address, and then executing all updates in parallel.
-  ///
-  /// [adsIdList] - A list of advertisement IDs that need to have their address
-  ///   updated.
-  /// [moveToId] - The ID of the new address to which all advertisements will be
-  ///   moved.
+  /// - Uploads images associated with the ad.
+  /// - Updates the ad object with the uploaded image URLs.
+  /// - Saves the ad to Firestore with an automatically generated ID.
   ///
   /// Returns:
-  /// - A `DataResult<void>` indicating success if all updates were completed
-  ///   successfully.
-  ///
-  /// Throws:
-  /// - `AdRepositoryException` if any of the updates fail, including an
-  ///   appropriate error message.
-  ///
-  // Future<DataResult<void>> moveAdsAddressTo(List<String> adsIdList, String moveToId);
-
-  /// Fetches a list of advertisement IDs that are associated with a specific
-  /// address.
-  ///
-  /// This method queries the Parse Server to find all advertisements linked to
-  /// the specified address. It returns the list of advertisement IDs, which
-  /// can be used to further interact with or display the ads.
-  ///
-  /// [addressId] - The unique identifier of the address to filter ads by.
-  ///
-  /// Returns:
-  /// - A `DataResult<List<String>>` containing a list of ad IDs if the query is
-  ///   successful. Otherwise, it returns an appropriate failure message.
-  ///
-  /// Throws:
-  /// - `AdRepositoryException` if the query operation fails, with a message
-  ///   detailing the issue.
-  ///
-  // Future<DataResult<List<String>>> adsInAddress(String addressId);
-
-  /// Updates the status of an existing advertisement in the Parse Server.
-  ///
-  /// This method takes an `AdModel` representing the advertisement whose status
-  /// needs to be updated. It creates a `ParseObject` for the specific
-  /// advertisement using its unique ID (`objectId`), and then attempts to
-  /// update the status field in the Parse Server database.
-  ///
-  /// [ad] - The `AdModel` instance that contains the updated status information
-  ///   and advertisement ID.
-  ///
-  /// Returns:
-  /// - A `DataResult<bool>` indicating whether the update operation was
-  ///   successful. If successful, it returns `true`.
-  ///
-  /// Throws:
-  /// - `AdRepositoryException` if the update operation fails, including an
-  ///   error message detailing the issue.
-  ///
-  Future<DataResult<void>> updateStatus(AdModel ad);
-
-  /// Fetches a list of advertisements associated with the current user and a
-  /// specific status.
-  ///
-  /// This method is designed to fetch advertisements from the Parse Server that
-  /// belong to the current logged-in user. It filters the ads based on a given
-  /// status, such as "active", "sold", or "pending". It also includes related
-  /// objects like the advertisement owner and address.
-  ///
-  /// [usr] - The `UserModel` instance representing the user requesting the ads.
-  /// [status] - The status of the advertisements to filter by, represented as
-  ///   an string.
-  ///
-  /// Returns:
-  /// - A `DataResult<List<AdModel>?>` that contains the user's advertisements
-  ///   if successful, or an appropriate failure message if not.
-  ///
-  /// Throws:
-  /// - `AdRepositoryException` if the query fails, indicating an issue with
-  ///   fetching the user ads.
-  ///
-  Future<DataResult<List<AdModel>?>> getMyAds(String userId, String status);
-
-  /// Fetches a list of advertisements from the Parse Server based on the
-  /// provided filters and search string.
-  ///
-  /// This method allows the client to retrieve advertisements with several
-  /// optional filters, including mechanics, price range, product condition,
-  /// and search term. Pagination is supported through the `page` parameter.
-  /// Sorting can be done either by date or by price.
-  ///
-  /// [filter] - The `FilterModel` used to apply different conditions like
-  ///   price, product condition, etc.
-  /// [search] - A search term used to filter advertisements by title.
-  /// [page] - The page number for pagination, used to retrieve ads in chunks
-  ///   (default is 0).
-  ///
-  /// Returns:
-  /// - A `DataResult<List<AdModel>?>` that contains a list of advertisements
-  ///   if successful, or an appropriate failure message if not.
-  ///
-  /// Throws:
-  /// - `AdRepositoryException` if the query operation fails.
-  ///
-  Future<DataResult<List<AdModel>?>> get(
-      {required FilterModel filter, required String search, int page = 0});
-
-  /// Saves a new advertisement to the Parse Server.
-  ///
-  /// This method takes an `AdModel` that represents the advertisement to be
-  /// saved and attempts to save the data to the Parse Server. It includes steps
-  /// to process related entities such as user information, images, address, and
-  /// boardgame data. If the operation fails, an `AdRepositoryException` is
-  /// thrown, and errors are handled accordingly.
-  ///
-  /// [ad] - The `AdModel` instance containing the data of the ad to be saved.
-  ///
-  /// Returns:
-  /// - A `DataResult<AdModel?>` indicating whether the save operation was
-  ///   successful. On success, it returns the saved `AdModel`.
-  ///
-  /// Throws:
-  /// - `AdRepositoryException` if the save operation fails with an appropriate
-  ///   error message.
-  ///
+  /// - [DataResult<AdModel?>]: Contains the saved ad with its Firestore ID.
   Future<DataResult<AdModel?>> add(AdModel ad);
 
-  /// Updates an existing advertisement in the Parse Server.
+  /// Retrieves ads from Firestore based on filters, search term, and pagination.
   ///
-  /// This method takes an `AdModel` representing the advertisement to be
-  /// updated and attempts to save the updated information in the Parse Server.
-  /// It first retrieves the current user, prepares any images to be saved,
-  /// and then updates the advertisement with the new data. If the operation
-  /// fails, an `AdRepositoryException` is thrown, and errors are handled
-  /// accordingly.
-  ///
-  /// [ad] - The `AdModel` instance containing the updated information of the
-  ///   ad.
+  /// - [filter]: A [FilterModel] containing filtering criteria.
+  /// - [search]: A search term to filter ads by title.
+  /// - [page]: Page number for pagination.
   ///
   /// Returns:
-  /// - A `DataResult<AdModel?>` indicating whether the update was successful.
-  ///   On success, it returns the updated `AdModel`.
+  /// - [DataResult<List<AdModel>?>]: A list of ads matching the filters.
+  Future<DataResult<List<AdModel>?>> get({
+    required FilterModel filter,
+    required String search,
+    int page = 0,
+  });
+
+  /// Retrieves a specific ad by its Firestore ID.
   ///
-  /// Throws:
-  /// - `AdRepositoryException` if the update fails with an appropriate error
-  ///   message.
+  /// - [adId]: The Firestore ID of the ad.
   ///
+  /// Returns:
+  /// - [DataResult<AdModel?>]: The ad if found, or null if it doesn't exist.
+  Future<DataResult<AdModel?>> getById(String id);
+
+  /// Retrieves ads created by a specific owner and filtered by status.
+  ///
+  /// - [ownerId]: The ID of the owner.
+  /// - [status]: The desired status of the ads.
+  ///
+  /// Returns:
+  /// - [DataResult<List<AdModel>?>]: A list of ads matching the filters.
+  Future<DataResult<List<AdModel>?>> getMyAds({
+    required String ownerId,
+    required AdStatus status,
+  });
+
+  /// Updates an existing ad in Firestore.
+  ///
+  /// - [ad]: The ad object containing updated information.
+  ///
+  /// Returns:
+  /// - [DataResult<AdModel?>]: Indicates success or failure of the operation.
   Future<DataResult<AdModel?>> update(AdModel ad);
 
-  /// Deletes an advertisement from the Parse Server.
+  /// Updates the status and quantity of an ad in Firestore.
   ///
-  /// This method attempts to delete a specific advertisement from the
-  /// Parse Server database using its unique ID. If the deletion is successful,
-  /// it returns a successful `DataResult` with a `null` value. If there is an
-  /// error during the deletion process, an `AdRepositoryException` is thrown,
-  /// and the error is handled accordingly.
+  /// - [adsId]: The Firestore ID of the ad.
+  /// - [status]: The new status of the ad.
+  /// - [quantity]: The new quantity of the ad.
   ///
-  /// [ad] - The unique identifier (objectId) of the advertisement to be
-  ///   deleted.
-  ///
-  /// Returns a `DataResult<void>` which indicates the success or failure of
-  /// the operation. If successful, returns a `DataResult.success(null)`.
-  ///
-  /// Throws:
-  /// - `AdRepositoryException` if the deletion fails, with the error message
-  ///   received from the Parse Server.
-  ///
-  Future<DataResult<void>> delete(String ad);
+  /// Returns:
+  /// - [DataResult<void>]: Indicates success or failure of the operation.
+  Future<DataResult<void>> updateStatus({
+    required String adsId,
+    required AdStatus status,
+    required int quantity,
+  });
 
-  Future<DataResult<AdModel?>> getById(String id);
+  /// Deletes an ad from Firestore by its ID.
+  ///
+  /// - [adId]: The Firestore ID of the ad to be deleted.
+  ///
+  /// Returns:
+  /// - [DataResult<void>]: Indicates success or failure of the operation.
+  Future<DataResult<void>> delete(String ad);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: boards
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.0.04+19
+version: 0.0.04+20
 
 environment:
   sdk: '>=3.4.1 <4.0.0'


### PR DESCRIPTION
This commit refines the advertisement management system by enhancing the repository interface, improving method signatures, and updating Firestore integration for better flexibility and performance.

### Changes made:

1. **lib/features/account/my_ads/my_ads_controller.dart**:
   - Updated `_getAds` method to use named parameters `ownerId` and `status` when calling `adRepository.getMyAds`.
   - Refactored `updateStatus` method to pass `adsId`, `status`, and `quantity` explicitly to `adRepository.updateStatus`.
   - Modified `deleteAd` method to use the updated `adRepository.updateStatus` method for marking ads as deleted.

2. **lib/repository/data/firebase/fb_ads_repository.dart**:
   - Added a new constant `keyAdsOwnerId` for the `ownerId` field in Firestore.
   - Implemented the `getMyAds` method to fetch ads based on `ownerId` and `status` using Firestore queries.
   - Updated `updateStatus` method to accept named parameters `adsId`, `status`, and `quantity` for improved clarity and flexibility.
   - Removed obsolete and unimplemented methods, including old `getMyAds` and placeholders for `moveAdsAddressTo`.

3. **lib/repository/data/interfaces/i_ads_repository.dart**:
   - Refactored method signatures in the `IAdsRepository` interface to use named parameters for clarity.
   - Removed extensive and outdated documentation for methods no longer relevant.
   - Updated `updateStatus` method to require `adsId`, `status`, and `quantity` as named parameters.
   - Simplified and streamlined method declarations to align with the latest implementation in Firestore.

### Conclusion:

These updates improve the modularity and maintainability of the advertisement management codebase. The repository interface now supports more flexible operations, and Firestore queries are streamlined for better performance. Deprecated methods and redundant documentation were cleaned up, ensuring the code remains clear and concise.